### PR TITLE
Handle commas/colons in attr defaults

### DIFF
--- a/lib/XML/BindData.pm
+++ b/lib/XML/BindData.pm
@@ -288,7 +288,8 @@ Only show the node if bool is true-ish. Can be negated as C<tmpl-if="!bool">.
 =item tmpl-attr-map="attr-name-one:opt1,attr-name-two:opt2"
 
 Bind the value of 'opt1' into the attribute 'attr-name-one'. Multiple
-attributes can be assigned at a time, separated by commas.
+attributes can be assigned at a time, separated by commas. Comma and colon
+characters in a default value must be preceded with a single backslash.
 
 =back
 

--- a/lib/XML/BindData.pm
+++ b/lib/XML/BindData.pm
@@ -64,7 +64,13 @@ sub parse_node {
 	}
 
         if ( my $attr_defaults = _strip_attr( $node, 'tmpl-attr-defaults' ) ) {
-            my @attributes = map { [ split qr/:/ ] } split qr/,/,
+            my @attributes
+                = map {
+                [   map { s/\\([:,])/$1/g; $_ } # remove backslash escaping
+                    split qr/(?<!\\):/          # split on non-backslashed colons
+                ]
+                }
+                split qr/(?<!\\),/,           # split on non-backslashed commas
                 $attr_defaults;
 
             foreach (@attributes) {

--- a/t/bind_data.t
+++ b/t/bind_data.t
@@ -60,6 +60,11 @@ my $tests = [
 	],
 
 	[
+		'<foo tmpl-attr-map="a:aaa,b:bbb" tmpl-attr-defaults="a:zzz,c:foo\,bar,d:foo\:bar"/>', { aaa => 0, bbb => 2 },
+		'<foo a="0" b="2" c="foo,bar" d="foo:bar"></foo>', 'Attribute defaults with commas and colons'
+	],
+
+	[
 		'<foo><bar tmpl-each="bar"><baz tmpl-each="this" tmpl-bind="this"/></bar></foo>',
 		{
 			bar => [


### PR DESCRIPTION
yuck! - suggestions welcome for a nicer way than negative lookbehind assertions, (then stripping the backslashes)