### PR TITLE
Attribute Default Fix

### DIFF
--- a/lib/XML/BindData.pm
+++ b/lib/XML/BindData.pm
@@ -68,8 +68,9 @@ sub parse_node {
                 $attr_defaults;
 
             foreach (@attributes) {
+                my $value = $node->getAttribute( $_->[0] );
                 $node->setAttribute( $_->[0], $_->[1] )
-                    unless defined $node->getAttribute( $_->[0] );
+                    if ! defined $value || $value eq ''; 
             }
         }
 

--- a/t/bind_data.t
+++ b/t/bind_data.t
@@ -50,9 +50,9 @@ my $tests = [
 	],
 
 	[
-		'<foo tmpl-attr-map="a:aaa,b:bbb" tmpl-attr-defaults="a:zzz,c:123"/>', { aaa => 1, bbb => 2 },
-		'<foo a="1" b="2" c="123"></foo>', 'Attribute defaults'
-	],
+		'<foo tmpl-attr-map="a:aaa,b:bbb,d:ddd" tmpl-attr-defaults="a:zzz,c:123,d:456"/>', { aaa => 1, bbb => 2 },
+		'<foo a="1" b="2" c="123" d="456"></foo>', 'Attribute defaults'
+    ],
 
 	[
 		'<foo tmpl-attr-map="a:aaa,b:bbb" tmpl-attr-defaults="a:zzz,c:0"/>', { aaa => 0, bbb => 2 },


### PR DESCRIPTION
This will hopefully make sense. You would expect the default value to be applied if you are not supplying a value to the attribute when you build the template, but this doesn't seem to be the case. It is only applied if it's not one of the attributes we are trying to map values for.

Probably best described by the test update.