### PR TITLE
Only include defined attributes via tmpl-attr-map

### DIFF
--- a/lib/XML/BindData.pm
+++ b/lib/XML/BindData.pm
@@ -60,7 +60,7 @@ sub parse_node {
 
 		foreach (@attributes) {
 			my $value = _get( $context, $_->[1] );
- 			$node->setAttribute( $_->[0], $value ) if defined $value;
+			$node->setAttribute( $_->[0], $value ) if defined $value;
 		}
 	}
 

--- a/lib/XML/BindData.pm
+++ b/lib/XML/BindData.pm
@@ -59,7 +59,8 @@ sub parse_node {
 		my @attributes = map { [ split qr/:/ ] } split qr/,/, $attr_map;
 
 		foreach (@attributes) {
-			$node->setAttribute($_->[0], _get($context, $_->[1]));
+			my $value = _get( $context, $_->[1] );
+ 			$node->setAttribute( $_->[0], $value ) if defined $value;
 		}
 	}
 

--- a/t/bind_data.t
+++ b/t/bind_data.t
@@ -50,6 +50,11 @@ my $tests = [
 	],
 
 	[
+		'<foo tmpl-attr-map="a:aaa,b:bbb,c:ccc"/>', { aaa => 1, bbb => 2 },
+		'<foo a="1" b="2"></foo>', 'Multiple attributes bind with undefined values'
+	],
+
+	[
 		'<foo tmpl-attr-map="a:aaa,b:bbb,d:ddd" tmpl-attr-defaults="a:zzz,c:123,d:456"/>', { aaa => 1, bbb => 2 },
 		'<foo a="1" b="2" c="123" d="456"></foo>', 'Attribute defaults'
     ],
@@ -57,6 +62,11 @@ my $tests = [
 	[
 		'<foo tmpl-attr-map="a:aaa,b:bbb" tmpl-attr-defaults="a:zzz,c:0"/>', { aaa => 0, bbb => 2 },
 		'<foo a="0" b="2" c="0"></foo>', 'Attribute defaults with false values'
+	],
+
+	[
+		'<foo tmpl-attr-map="a:aaa,b:bbb" tmpl-attr-defaults="a:zzz,c:0"/>', { aaa => undef, bbb => 2 },
+		'<foo a="zzz" b="2" c="0"></foo>', 'Attribute defaults with undefined values'
 	],
 
 	[

--- a/t/bind_data.t
+++ b/t/bind_data.t
@@ -65,7 +65,7 @@ my $tests = [
 	],
 
 	[
-		'<foo tmpl-attr-map="a:aaa,b:bbb" tmpl-attr-defaults="a:zzz,c:0"/>', { aaa => undef, bbb => 2 },
+		'<foo tmpl-attr-map="a:aaa,b:bbb,c:ccc,d:ddd" tmpl-attr-defaults="a:zzz,c:0"/>', { aaa => undef, bbb => 2 },
 		'<foo a="zzz" b="2" c="0"></foo>', 'Attribute defaults with undefined values'
 	],
 


### PR DESCRIPTION
Currently tmpl-attr-map includes an attribute with an empty string value if an attribute is not defined in the data.

This PR only includes mapped attributes if there is a defined value.